### PR TITLE
文字<->数字のアルゴリズムを変える

### DIFF
--- a/.run/E2E (p=17, l=2, γ'=11, k=2, m=_a, b, c, d, e, f. hi, alice._ r_0=7).run.xml
+++ b/.run/E2E (p=17, l=2, γ'=11, k=2, m=_a, b, c, d, e, f. hi, alice._ r_0=7).run.xml
@@ -1,24 +1,27 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="ENC (p=17, l=2, γ'=11, k=2, m=&quot;Text Message&quot;)" type="PythonConfigurationType" factoryName="Python" folderName="Encrypt &amp; Decrypt">
+  <configuration default="false" name="E2E (p=17, l=2, γ'=11, k=2, m=&quot;a, b, c, d, e, f. hi, alice.&quot; r_0=7)" type="PythonConfigurationType" factoryName="Python" folderName="End-to-End">
     <module name="cyclotomic-matries" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/.asdf/shims/python" />
+    <option name="SDK_NAME" value="Python 3.10" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="IS_MODULE_SDK" value="true" />
+    <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/encrypt.py" />
-    <option name="PARAMETERS" value="17 2 11 2 &quot;a, b, c, d, e, f. hi, alice.&quot;" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/decrypt.py" />
+    <option name="PARAMETERS" value="7" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="false" run_configuration_name="ENC (p=17, l=2, γ'=11, k=2, m=&quot;Text Message&quot;)" run_configuration_type="PythonConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/.run/ENC (p=17, l=2, γ'=11, k=2, m=_Text Message_).run.xml
+++ b/.run/ENC (p=17, l=2, γ'=11, k=2, m=_Text Message_).run.xml
@@ -13,7 +13,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/encrypt.py" />
-    <option name="PARAMETERS" value="17 2 11 2 &quot;Text Message&quot;" />
+    <option name="PARAMETERS" value="17 2 11 2 &quot;a, b, c, d, e, f. hi, alice.&quot;" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.run/ENC (p=17, l=2, γ'=11, k=2, m=_a, b, c, d, e, f. hi, alice._).run.xml
+++ b/.run/ENC (p=17, l=2, γ'=11, k=2, m=_a, b, c, d, e, f. hi, alice._).run.xml
@@ -1,27 +1,24 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="E2E (p=17, l=2, γ'=11, k=2, m=&quot;Text Message&quot; r_0=7)" type="PythonConfigurationType" factoryName="Python" folderName="End-to-End">
+  <configuration default="false" name="ENC (p=17, l=2, γ'=11, k=2, m=&quot;a, b, c, d, e, f. hi, alice.&quot;)" type="PythonConfigurationType" factoryName="Python" folderName="Encrypt &amp; Decrypt">
     <module name="cyclotomic-matries" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/.asdf/shims/python" />
-    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/decrypt.py" />
-    <option name="PARAMETERS" value="7" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/encrypt.py" />
+    <option name="PARAMETERS" value="17 2 11 2 &quot;a, b, c, d, e, f. hi, alice.&quot;" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
-    <method v="2">
-      <option name="RunConfigurationTask" enabled="false" run_configuration_name="ENC (p=17, l=2, γ'=11, k=2, m=&quot;Text Message&quot;)" run_configuration_type="PythonConfigurationType" />
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/src/decrypt.py
+++ b/src/decrypt.py
@@ -74,7 +74,7 @@ def main():
     inverse_cyclotomic_matrix = inverse_cyclotomic_matrix.astype(int)
     print_matrix(inverse_cyclotomic_matrix, "Int version of it")
 
-    matrix_converter = MatrixConverter(l)
+    matrix_converter = MatrixConverter(l, p)
 
     print_matrix(cipher_matrix, "Cypher Matrix")
 

--- a/src/encrypt.py
+++ b/src/encrypt.py
@@ -22,7 +22,7 @@ def encrypt_message(p: int, l: int, generator: int, k: int,
     :return:
     """
     # Convert the message input to a message matrix
-    mc = MatrixConverter(l)
+    mc = MatrixConverter(l, p)
     if isinstance(message_input, str):
         message_matrix = mc.str_to_matrix(message_input)
     elif isinstance(message_input, np.ndarray):

--- a/src/matrix_converter.py
+++ b/src/matrix_converter.py
@@ -4,12 +4,12 @@ import string
 
 class MatrixConverter:
     def __init__(self, l, p):
-        if p > 62:
-            raise ValueError("p cannot exceed 62.")
+        if p > 65:
+            raise ValueError("p cannot exceed 65.")
         self.l = l
         self.p = p
-        self.char_list = list(string.ascii_lowercase[:p]) + list(
-            string.digits[:max(0, p - 26)]) + list(string.ascii_uppercase[:max(0, p - 36)])
+        self.char_list = list(' ,.') + list(string.ascii_lowercase[:p - 3]) + list(
+            string.digits[:max(0, p - 29)]) + list(string.ascii_uppercase[:max(0, p - 39)])
 
     def char_to_int(self, c):
         try:

--- a/src/matrix_converter.py
+++ b/src/matrix_converter.py
@@ -1,15 +1,27 @@
 import numpy as np
+import string
 
 
 class MatrixConverter:
-    def __init__(self, l):
+    def __init__(self, l, p):
+        if p > 62:
+            raise ValueError("p cannot exceed 62.")
         self.l = l
+        self.p = p
+        self.char_list = list(string.ascii_lowercase[:p]) + list(
+            string.digits[:max(0, p - 26)]) + list(string.ascii_uppercase[:max(0, p - 36)])
 
     def char_to_int(self, c):
-        return ord(c)
+        try:
+            return self.char_list.index(c)
+        except ValueError:
+            raise ValueError(f"Character {c} not in char_list.")
 
     def int_to_char(self, i):
-        return chr(int(i))
+        try:
+            return self.char_list[i]
+        except IndexError:
+            raise ValueError(f"Index {i} out of range for char_list.")
 
     def str_to_matrix(self, s):
         matrix_size = 2 * self.l ** 2


### PR DESCRIPTION
# matrix_converterの仕様変更

- 初期化時に`p`（使用可能な文字の種類数）を引数として受け取る
- 使用可能な文字のリスト`char_list`の作成
  - このリストは、半角空白、カンマ、ピリオド、小文字のアルファベット、数字、大文字のアルファベットを順に含み、合計で最大65種類の文字を含むことが可能
  - これは後々増やす
- `char_to_int`メソッドと`int_to_char`メソッドのアップデート
  - 任意の`p`種類の文字を使用して文字列と行列の間の変換を行う
- 文字がリストの範囲外だった場合や数がリストの範囲外だった場合はとりあえずエラーを吐かす