### PR TITLE
逆行列計算のアルゴリズムを `numpy.linalg.inv` から逆元の乗算による逆行列計算アルゴリズムに置き換える

### DIFF
--- a/.run/E2E (p=17, l=2, γ'=11, k=2, m=_a, b, c, d, e, f. hi, alice._ r_0=7).run.xml
+++ b/.run/E2E (p=17, l=2, γ'=11, k=2, m=_a, b, c, d, e, f. hi, alice._ r_0=7).run.xml
@@ -21,7 +21,7 @@
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2">
-      <option name="RunConfigurationTask" enabled="false" run_configuration_name="ENC (p=17, l=2, γ'=11, k=2, m=&quot;Text Message&quot;)" run_configuration_type="PythonConfigurationType" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="ENC (p=17, l=2, γ'=11, k=2, m=&quot;a, b, c, d, e, f. hi, alice.&quot;)" run_configuration_type="PythonConfigurationType" />
     </method>
   </configuration>
 </component>

--- a/src/cyclotomic_matrix.py
+++ b/src/cyclotomic_matrix.py
@@ -6,6 +6,8 @@ import numpy as np
 from numpy import ndarray
 from numpy.linalg import LinAlgError, inv
 
+from src.inverse_matrix_modulo import matrix_inverse_modulo
+
 
 def power(base: int, exponent: int) -> int:
     return base ** exponent
@@ -136,15 +138,7 @@ class CyclotomicMatrix:
             for b in range(self.size):
                 n_matrix[a][b] = self.matrix[a][b].n
 
-        # 正則行列であることを確認
-        assert np.linalg.det(n_matrix) != 0, "The matrix is not regular."
-
-        # 逆行列を計算
-        try:
-            inv_matrix = inv(n_matrix)
-        except LinAlgError:
-            print("The matrix is not invertible.")
-            return None
+        inv_matrix = matrix_inverse_modulo(n_matrix, self.p)
 
         return inv_matrix
 

--- a/src/cyclotomic_matrix.py
+++ b/src/cyclotomic_matrix.py
@@ -122,7 +122,7 @@ class CyclotomicMatrix:
                 self.matrix[a][b] = Entry(l_new, m_new, n)
         return self
 
-    def inv(self) -> ndarray | None:
+    def inv(self) -> ndarray:
         """
         逆行列の計算を行う.
 

--- a/src/decrypt.py
+++ b/src/decrypt.py
@@ -81,6 +81,8 @@ def main():
     message_matrix = inverse_cyclotomic_matrix @ cipher_matrix
     print_matrix(message_matrix, "Message Matrix")
 
+    print_matrix(np.mod(message_matrix, p), "Message Matrix (Modulused by p)")
+
     message_str = matrix_converter.matrix_to_str(message_matrix)
     print(f"Decrypted Message: {message_str}")
 

--- a/src/inverse_matrix_modulo.py
+++ b/src/inverse_matrix_modulo.py
@@ -1,16 +1,16 @@
 import numpy as np
 
 
-def multiplicative_inverse(a, p):
-    for i in range(1, p):
-        if (i * a) % p == 1:
+def multiplicative_inverse(a, modulus):
+    for i in range(1, modulus):
+        if (i * a) % modulus == 1:
             return i
     return -1
 
 
-def matrix_inverse_modulo_p(matrix, p):
+def matrix_inverse_modulo(matrix, modulus):
     n = len(matrix)
-    matrix = matrix % p
+    matrix = matrix % modulus
     augmented_matrix = np.hstack((matrix.astype(int), np.eye(n, dtype=int)))
     for i in range(n):
         if augmented_matrix[i][i] == 0:
@@ -20,13 +20,14 @@ def matrix_inverse_modulo_p(matrix, p):
                     break
             else:
                 raise ValueError("行列は法pにおいて可逆ではありません (Matrix is not invertible modulo p)")
-        pivot_element = multiplicative_inverse(augmented_matrix[i][i], p)
-        augmented_matrix[i] = (augmented_matrix[i] * pivot_element) % p
+        pivot_element = multiplicative_inverse(augmented_matrix[i][i], modulus)
+        augmented_matrix[i] = (augmented_matrix[i] * pivot_element) % modulus
         for j in range(n):
             if i != j:
                 factor = augmented_matrix[j][i]
                 augmented_matrix[j, i:] = (
-                        (augmented_matrix[j, i:] - factor * augmented_matrix[i, i:]) % p).astype(
+                        (augmented_matrix[j, i:] - factor * augmented_matrix[i,
+                                                            i:]) % modulus).astype(
                     int)
-    inverse_matrix = augmented_matrix[:, n:] % p
+    inverse_matrix = augmented_matrix[:, n:] % modulus
     return inverse_matrix

--- a/src/inverse_matrix_modulo_p.py
+++ b/src/inverse_matrix_modulo_p.py
@@ -19,7 +19,7 @@ def matrix_inverse_modulo_p(matrix, p):
                     augmented_matrix[[i, j]] = augmented_matrix[[j, i]]
                     break
             else:
-                return "行列は法pにおいて可逆ではありません"
+                raise ValueError("行列は法pにおいて可逆ではありません (Matrix is not invertible modulo p)")
         pivot_element = multiplicative_inverse(augmented_matrix[i][i], p)
         augmented_matrix[i] = (augmented_matrix[i] * pivot_element) % p
         for j in range(n):

--- a/src/matrix_converter.py
+++ b/src/matrix_converter.py
@@ -17,11 +17,14 @@ class MatrixConverter:
         except ValueError:
             raise ValueError(f"Character {c} not in char_list.")
 
-    def int_to_char(self, i):
+    def int_to_char(self, i, modulus):
+        if modulus < 1 or modulus > len(self.char_list):
+            raise ValueError(f"Modulus {modulus} is out of range.")
+        i %= modulus
         try:
             return self.char_list[i]
         except IndexError:
-            raise ValueError(f"Index {i} out of range for char_list.")
+            raise ValueError(f"Unexpected error: index {i} out of range for char_list.")
 
     def str_to_matrix(self, s):
         matrix_size = 2 * self.l ** 2
@@ -36,4 +39,4 @@ class MatrixConverter:
 
     def matrix_to_str(self, matrix):
         flat_list = matrix.flatten().tolist()
-        return ''.join(self.int_to_char(i) for i in flat_list)
+        return ''.join(self.int_to_char(i, self.p) for i in flat_list)

--- a/tests/test_cyclotomic_matrix.py
+++ b/tests/test_cyclotomic_matrix.py
@@ -31,11 +31,16 @@ def test_mul():
 
 
 def test_inv():
-    cm = CyclotomicMatrix(p=17, l=2, generator=3, k=2).mul(r_0=7)
+    p = 17
+    l = 2
+    generator = 3
+    k = 2
+    r_0 = 7
+    cm = CyclotomicMatrix(p=p, l=l, generator=generator, k=k).mul(r_0=r_0)
     inv_matrix = cm.inv()
 
-    # D*
-    expected_output = np.array([
+    # D* (Z)
+    expected_output = np.mod(np.array([
         [-1, 1, 1, -1, -1, 1, -1, 1],
         [1, 0, 0, 1, 0, 0, 0, -1],
         [1, 0, 0, 0, 0, 0, 0, 0],
@@ -44,7 +49,7 @@ def test_inv():
         [1, 0, 0, 1, 0, -1, 1, -1],
         [-1, 0, 0, -1, 0, 1, 0, 1],
         [1, -1, 0, 1, 1, -1, 1, -1]
-    ])
+    ]), p)
 
     np.testing.assert_array_equal(inv_matrix, expected_output)
 

--- a/tests/test_inverse_matrix_modulo.py
+++ b/tests/test_inverse_matrix_modulo.py
@@ -3,7 +3,7 @@ import re
 import numpy as np
 import pytest
 
-from src.inverse_matrix_modulo_p import matrix_inverse_modulo_p
+from src.inverse_matrix_modulo import matrix_inverse_modulo
 
 
 # 逆行列が存在する場合のテストケース
@@ -22,8 +22,8 @@ from src.inverse_matrix_modulo_p import matrix_inverse_modulo_p
     # 常に可逆とは限らないので修正した方がいいかも
     (np.random.randint(1, 100, (10, 10)), 97),
 ])
-def test_matrix_inverse_modulo_p(matrix, modulus):
-    inverse_matrix = matrix_inverse_modulo_p(matrix, modulus)
+def test_matrix_inverse_modulo(matrix, modulus):
+    inverse_matrix = matrix_inverse_modulo(matrix, modulus)
     identity_matrix = np.eye(len(matrix), dtype=int)
     assert np.array_equal((np.dot(matrix, inverse_matrix) % modulus), identity_matrix)
 
@@ -42,8 +42,8 @@ def test_matrix_inverse_modulo_p(matrix, modulus):
     (np.array([[11, 22], [2, 4]]), 23),
     (np.ones((10, 10), dtype=int), 97),  # 10x10 matrix with all values 1, modulus is a prime number
 ])
-def test_matrix_inverse_modulo_p_error(matrix, modulus):
+def test_matrix_inverse_modulo_error(matrix, modulus):
     with pytest.raises(ValueError,
                        match=re.escape(
                            "行列は法pにおいて可逆ではありません (Matrix is not invertible modulo p)")):
-        matrix_inverse_modulo_p(matrix, modulus)
+        matrix_inverse_modulo(matrix, modulus)

--- a/tests/test_inverse_matrix_modulo_p.py
+++ b/tests/test_inverse_matrix_modulo_p.py
@@ -1,23 +1,49 @@
+import re
+
 import numpy as np
+import pytest
+
 from src.inverse_matrix_modulo_p import matrix_inverse_modulo_p
 
 
-def test_matrix_inverse_modulo_p():
-    matrix = np.array([[2, 1], [5, 3]])
-    print("Original matrix:")
-    print(matrix)
-    p = 7
-    expected_inverse = np.array([[6, 1], [2, 2]])
-    calculated_inverse = matrix_inverse_modulo_p(matrix, p)
-    print("Calculated inverse:")
-    print(calculated_inverse)
-    print("int version of calculated inverse:")
-    print(calculated_inverse.astype(int))
-    print("Expected inverse:")
-    print(expected_inverse)
-    assert np.array_equal(calculated_inverse, expected_inverse), "Test failed!"
-    print("Test passed!")
+# 逆行列が存在する場合のテストケース
+@pytest.mark.parametrize("matrix, modulus", [
+    (np.array([[2, 1], [5, 3]]), 7),
+    (np.array([[1, 2], [3, 4]]), 5),
+    (np.array([[3, 3], [2, 5]]), 7),
+    (np.array([[2, 5], [1, 6]]), 11),
+    (np.array([[4, 7], [2, 6]]), 11),
+    (np.array([[6, 2], [1, 8]]), 13),
+    (np.array([[7, 4], [5, 2]]), 13),
+    (np.array([[8, 3], [4, 7]]), 17),
+    (np.array([[9, 6], [3, 8]]), 19),
+    (np.array([[10, 7], [5, 9]]), 23),
+    # 10x10 matrix with values from 1 to 100, modulus is a prime number
+    # 常に可逆とは限らないので修正した方がいいかも
+    (np.random.randint(1, 100, (10, 10)), 97),
+])
+def test_matrix_inverse_modulo_p(matrix, modulus):
+    inverse_matrix = matrix_inverse_modulo_p(matrix, modulus)
+    identity_matrix = np.eye(len(matrix), dtype=int)
+    assert np.array_equal((np.dot(matrix, inverse_matrix) % modulus), identity_matrix)
 
 
-if __name__ == "__main__":
-    test_matrix_inverse_modulo_p()
+# 逆行列が存在しない場合のテストケース
+@pytest.mark.parametrize("matrix, modulus", [
+    (np.array([[2, 4], [1, 2]]), 7),
+    (np.array([[3, 6], [1, 2]]), 5),
+    (np.array([[4, 8], [2, 4]]), 7),
+    (np.array([[5, 10], [2, 4]]), 11),
+    (np.array([[6, 12], [3, 6]]), 11),
+    (np.array([[7, 14], [2, 4]]), 13),
+    (np.array([[8, 16], [4, 8]]), 13),
+    (np.array([[9, 18], [3, 6]]), 17),
+    (np.array([[10, 20], [5, 10]]), 19),
+    (np.array([[11, 22], [2, 4]]), 23),
+    (np.ones((10, 10), dtype=int), 97),  # 10x10 matrix with all values 1, modulus is a prime number
+])
+def test_matrix_inverse_modulo_p_error(matrix, modulus):
+    with pytest.raises(ValueError,
+                       match=re.escape(
+                           "行列は法pにおいて可逆ではありません (Matrix is not invertible modulo p)")):
+        matrix_inverse_modulo_p(matrix, modulus)


### PR DESCRIPTION
- [x] 逆行列計算のアルゴリズムを `numpy.linalg.inv` から逆元の乗算による逆行列計算アルゴリズムに置き換える
- [x] 数字->文字の変換においてmodulusで剰余を取る